### PR TITLE
Deploy Bun commands through private command server

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -74,10 +74,17 @@ jobs:
 
           retry 5 kubectl set image statefulset/flow-server flow-server=$ECR/flow-server:$COMMIT
           retry 5 kubectl set image statefulset/deno-server deno-server=$ECR/cmds-server:$COMMIT init=$ECR/cmds-server:$COMMIT
+          retry 5 kubectl set image statefulset/private-cmds-server private-cmds-server=$ECR/cmds-server:$COMMIT init=$ECR/cmds-server:$COMMIT
+          retry 5 kubectl set env statefulset/private-cmds-server DENO_DIR=/data/deno
+          retry 5 kubectl patch statefulset/private-cmds-server --type='json' -p='[
+            {"op":"replace","path":"/spec/template/spec/containers/0/command","value":["all-cmds-server"]},
+            {"op":"replace","path":"/spec/template/spec/initContainers/0/imagePullPolicy","value":"Always"}
+          ]'
           retry 5 kubectl set image deployment/schema-server schema-server=$ECR/schema-server:$COMMIT
 
           retry 5 kubectl rollout status statefulset/flow-server --timeout=10m
           retry 5 kubectl rollout status statefulset/deno-server --timeout=10m
+          retry 5 kubectl rollout status statefulset/private-cmds-server --timeout=10m
           retry 5 kubectl rollout status deployment/schema-server --timeout=10m
 
   integration-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
 name = "all-cmds-server"
 version = "0.1.0"
 dependencies = [
+ "cmds-bun",
  "cmds-image",
  "cmds-pdg",
  "cmds-solana",

--- a/crates/all-cmds-server/Cargo.toml
+++ b/crates/all-cmds-server/Cargo.toml
@@ -8,4 +8,5 @@ cmds-std.workspace = true
 cmds-pdg.workspace = true
 cmds-solana.workspace = true
 cmds-image.workspace = true
+cmds-bun.workspace = true
 flow-rpc.workspace = true

--- a/crates/all-cmds-server/src/main.rs
+++ b/crates/all-cmds-server/src/main.rs
@@ -1,3 +1,4 @@
+use cmds_bun as _;
 use cmds_image as _;
 use cmds_pdg as _;
 use cmds_solana as _;


### PR DESCRIPTION
## Summary
- include cmds-bun in all-cmds-server so Umbra Bun nodes are in the built cmds-server image
- deploy private-cmds-server from the pinned cmds-server commit image instead of the stale private-cmds-server:latest image
- keep the private command server StatefulSet on the normal main deploy path

## Test
- bun test ./crates/cmds-bun/src/umbra/umbra_common.ts
- cargo check -p all-cmds-server