### PR TITLE
Ensure Umbra registration before UTXO creation

### DIFF
--- a/crates/cmds-bun/node-definitions/umbra/umbra_create_utxo.jsonc
+++ b/crates/cmds-bun/node-definitions/umbra/umbra_create_utxo.jsonc
@@ -49,6 +49,15 @@
         "tooltip": "Optional sponsored transaction fee payer as a base58 64-byte Solana secret key. Prefer this for backend-sponsored flows because Flow wallet materialization may convert fee_payer into a pubkey."
       },
       {
+        "name": "ensure_registered",
+        "type_bounds": [
+          "bool"
+        ],
+        "required": false,
+        "passthrough": false,
+        "tooltip": "Ensure the depositor is registered for confidential and anonymous Umbra usage before creating the UTXO. Defaults to true."
+      },
+      {
         "name": "network",
         "type_bounds": [
           "string"

--- a/crates/cmds-bun/node-definitions/umbra/umbra_register.jsonc
+++ b/crates/cmds-bun/node-definitions/umbra/umbra_register.jsonc
@@ -40,6 +40,15 @@
         "tooltip": "Optional sponsored transaction fee payer. The Umbra signer remains the user/depositor, while this signer pays Solana transaction fees and Umbra fee_payer rent accounts when supported."
       },
       {
+        "name": "fee_payer_secret",
+        "type_bounds": [
+          "string"
+        ],
+        "required": false,
+        "passthrough": false,
+        "tooltip": "Optional sponsored transaction fee payer as a base58 64-byte Solana secret key. Prefer this for backend-sponsored flows because Flow wallet materialization may convert fee_payer into a pubkey."
+      },
+      {
         "name": "network",
         "type_bounds": [
           "string"

--- a/crates/cmds-bun/src/umbra/umbra_create_utxo.ts
+++ b/crates/cmds-bun/src/umbra/umbra_create_utxo.ts
@@ -1,5 +1,8 @@
 import { BaseCommand, Context } from "@space-operator/flow-lib-bun";
-import { getPublicBalanceToReceiverClaimableUtxoCreatorFunction } from "@umbra-privacy/sdk";
+import {
+  getPublicBalanceToReceiverClaimableUtxoCreatorFunction,
+  getUserRegistrationFunction,
+} from "@umbra-privacy/sdk";
 import {
   createUmbraClient,
   createRustProver,
@@ -11,6 +14,26 @@ import {
   wrapZkProver,
 } from "./umbra_common.ts";
 
+function createRegistrationCallbacks() {
+  const stepLogger = (step: string) => ({
+    pre: async (ctx: any) => {
+      console.log(`[create_utxo:register] phase: ${step}_start skipped=${Boolean(ctx?.skipped)}`);
+    },
+    post: async (ctx: any) => {
+      const signature = typeof ctx?.signature === "string" ? ` signature=${ctx.signature}` : "";
+      console.log(
+        `[create_utxo:register] phase: ${step}_complete skipped=${Boolean(ctx?.skipped)}${signature}`,
+      );
+    },
+  });
+
+  return {
+    userAccountInitialisation: stepLogger("user_account_initialisation"),
+    registerX25519PublicKey: stepLogger("register_x25519_public_key"),
+    registerUserForAnonymousUsage: stepLogger("register_user_for_anonymous_usage"),
+  };
+}
+
 export default class UmbraCreateUtxo extends BaseCommand {
   override async run(ctx: Context, inputs: any): Promise<any> {
     console.log("[create_utxo] phase: client_creation");
@@ -21,6 +44,33 @@ export default class UmbraCreateUtxo extends BaseCommand {
       ctx,
       resolveUmbraFeePayerBytes(inputs),
     );
+
+    if (inputs.ensure_registered !== false) {
+      console.log("[create_utxo] phase: registration_prover_init");
+      const registrationProver = wrapZkProver(
+        "create_utxo:register",
+        createRustProver("userRegistration"),
+      );
+      const register = getUserRegistrationFunction(
+        { client },
+        { zkProver: registrationProver } as any,
+      );
+
+      try {
+        console.log("[create_utxo] phase: ensure_registration");
+        await register({
+          confidential: true,
+          anonymous: true,
+          callbacks: createRegistrationCallbacks(),
+        } as any);
+        console.log("[create_utxo] phase: ensure_registration_complete");
+      } catch (err: any) {
+        const details = logUmbraError("create_utxo:register", err);
+        throw new Error(
+          `Umbra registration failed (${details.phase}): ${details.message}${details.cause ? ` — cause: ${details.cause}` : ""}`,
+        );
+      }
+    }
 
     console.log("[create_utxo] phase: prover_init");
     let zkProver: any;


### PR DESCRIPTION
## Summary\n- make umbra_create_utxo idempotently register the depositor for confidential + anonymous Umbra usage before creating the UTXO\n- expose ensure_registered on create_utxo and fee_payer_secret on umbra_register node definitions\n\n## Tests\n- bun test ./crates/cmds-bun/src/umbra/umbra_create_utxo.ts ./crates/cmds-bun/src/umbra/umbra_register.ts ./crates/cmds-bun/src/umbra/umbra_common.ts\n- cargo check -p all-cmds-server\n